### PR TITLE
Handle empty arguments.

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -592,6 +592,8 @@ class TypeConverter(object):
         default = []
 
         def add_parameter():
+            if not type_modifiers:
+                return
             if default:
                 del default[0]  # Remove flag.
             end = type_modifiers[-1].end

--- a/test_ast.py
+++ b/test_ast.py
@@ -480,6 +480,36 @@ class AstBuilderIntegrationTest(unittest.TestCase):
 
     """
 
+    def test_no_argument(self):
+        nodes = list(MakeBuilder('FOO();').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], []), nodes[0])
+
+    def test_one_argument(self):
+        nodes = list(MakeBuilder('FOO(1);').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], list(get_tokens('1'))), nodes[0])
+
+    def test_two_arguments(self):
+        nodes = list(MakeBuilder('FOO(1,0);').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], list(get_tokens('1,0'))), nodes[0])
+
+    def test_two_arguments_first_empty(self):
+        nodes = list(MakeBuilder('FOO( ,0);').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], list(get_tokens('0'))), nodes[0])
+
+    def test_two_arguments_second_empty(self):
+        nodes = list(MakeBuilder('FOO(1, );').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], list(get_tokens('1'))), nodes[0])
+
+    def test_two_arguments_both_empty(self):
+        nodes = list(MakeBuilder('FOO( , );').generate())
+        self.assertEqual(1, len(nodes))
+        self.assertEqual(Function('FOO', [], []), nodes[0])
+
     def test_class_variable_declaration(self):
         nodes = list(MakeBuilder('class Foo foo;').generate())
         self.assertEqual(1, len(nodes))


### PR DESCRIPTION
Empty arguments may appear when parsing macro for example.
