### PR TITLE
Fix warning about unused include

### DIFF
--- a/test/baz.h
+++ b/test/baz.h
@@ -1,0 +1,3 @@
+#include "bar.h"
+
+void fct(Bar& bar);

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -1,3 +1,4 @@
+test/baz.h:1: test/bar.h does not need to be #included. Use a forward declaration instead
 test/empty.cc: Unable to find header file with matching name
 test/foo.h:14: 'Unused' not used
 test/foo.h:61: 'ProtoArray' not used


### PR DESCRIPTION
When a type is only used in function declaration as pointer or reference, the include is indead useless but add information in the error message that the type must be forward declared
