### PR TITLE
Improve tokenizer ('^=', '|=', '<<=', '>>=', ...).

### DIFF
--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -401,8 +401,7 @@ class WarningHunter(object):
                 # If the primary.filename == header.filename, it probably
                 # indicates an error elsewhere. It sucks to mask it,
                 # but false positives are worse.
-                if (primary_header and
-                        primary_header.filename != header.filename):
+                if primary_header:
                     msg = ("expected to find '{}' in '{}', "
                            "but found in '{}'".format(name,
                                                       primary_header.filename,

--- a/cpp/tokenize.py
+++ b/cpp/tokenize.py
@@ -158,15 +158,22 @@ def get_tokens(source):
             elif source[i] == "'" and source[start:i] in _STR_PREFIXES:
                 token_type = CONSTANT
                 i = _get_string(source, i)
-        elif c == '/' and source[i + 1] == '/':    # Find // comments.
+        elif c == '/' and source[i + 1] == '/':  # Find // comments.
             i = source.find('\n', i)
-            if i == -1:  # Handle EOF.
-                i = end
             continue
-        elif c == '/' and source[i + 1] == '*':    # Find /* comments. */
+        elif c == '/' and source[i + 1] == '*':  # Find /* comments. */
             i = source.find('*/', i) + 2
             continue
-        elif c in ':+-<>&!|*=':                   # : or :: (plus other chars).
+        elif c in '<>':                          # Handle '<' and '>' tokens.
+            token_type = SYNTAX
+            i += 1
+            new_ch = source[i]
+            if new_ch == c:
+                i += 1
+                new_ch = source[i]
+            if new_ch == '=':
+                i += 1
+        elif c in ':+-&|=':                      # Handle 'XX' and 'X=' tokens.
             token_type = SYNTAX
             i += 1
             new_ch = source[i]
@@ -176,7 +183,13 @@ def get_tokens(source):
                 i += 1
             elif new_ch == '=':
                 i += 1
-        elif c in '()[]{}~?^%;/.,':             # Handle single char tokens.
+        elif c in '!*^%/':                       # Handle 'X=' tokens.
+            token_type = SYNTAX
+            i += 1
+            new_ch = source[i]
+            if new_ch == '=':
+                i += 1
+        elif c in '()[]{}~?;.,':                 # Handle single char tokens.
             token_type = SYNTAX
             i += 1
             if c == '.' and source[i].isdigit():

--- a/test/macro3.h
+++ b/test/macro3.h
@@ -1,5 +1,7 @@
 MyMacro(NS, Name)
 
 namespace NS {
-
+MyMacro()
+MyMacro(NS)
+MyMacro(NS, Name)
 }

--- a/test_ast.py
+++ b/test_ast.py
@@ -661,7 +661,7 @@ class AstBuilderIntegrationTest(unittest.TestCase):
 
     def test_operators(self):
         for operator in ('=', '+=', '-=', '*=', '==', '!=', '()', '[]', '<',
-                         '>'):
+                         '>', '^=', '<<=', '>>='):
             code = 'void Foo::operator%s();' % operator
             nodes = list(MakeBuilder(code).generate())
             self.assertEqual(1, len(nodes))

--- a/test_tokenize.py
+++ b/test_tokenize.py
@@ -87,7 +87,7 @@ class TokenizeTest(unittest.TestCase):
             self.assertEqual(Constant('3', 4, 5), tokens[2])
 
     def testget_tokens_multi_char_binary_operators(self):
-        for operator in ('<<', '>>', '**'):
+        for operator in ('<<', '>>'):
             #                        0123456
             tokens = self.get_tokens('5 %s 3' % operator)
             self.assertEqual(3, len(tokens), tokens)
@@ -119,7 +119,8 @@ class TokenizeTest(unittest.TestCase):
         self.assertEqual(Name('not', 1, 4), tokens[1])
 
     def testget_tokens_operators(self):
-        for operator in ('+=', '-=', '*=', '==', '!='):
+        for operator in ('+=', '-=', '*=', '==', '!=', '/=', '%=', '^=', '|=',
+                         '<<', '>>', '<=', '>='):
             #                        0123456
             tokens = self.get_tokens('a %s b' % operator)
             self.assertEqual(3, len(tokens), tokens)


### PR DESCRIPTION
More robust parser (better handling of macro without trailing semi-colon).
