### PR TITLE
Handle ref-qualifiers.

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -1076,6 +1076,10 @@ class AstBuilder(object):
                 self._add_back_token(token)
                 token = tokenize.Token(tokenize.SYNTAX, ';', 0, 0)
 
+        # Handle ref-qualifiers.
+        if token.name == '&' or token.name == '&&':
+            token = self._get_next_token()
+
         if token.name == '}':
             self._add_back_token(token)
             token = tokenize.Token(tokenize.SYNTAX, ';', 0, 0)

--- a/test/foo.h
+++ b/test/foo.h
@@ -274,3 +274,8 @@ map<string, const Flag*> ReturnFlags();
 vector<string*> string_list;
 
 class Foo::Bar { Bar() { XXX(1) << "should work"; } };
+
+class Optional {
+  void getValue() & { }
+  void getValue() && { }
+};


### PR DESCRIPTION
Fix parsing for this king of code:
class Optional {
  void getValue() & { }
  void getValue() && { }
};
