### PR TITLE
Better heuristic to decide if an argument has a name or not.

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -609,10 +609,19 @@ class TypeConverter(object):
                 del default[0]  # Remove flag.
             end = type_modifiers[-1].end
 
-            needs_name_removed = not (
-                len(type_modifiers) == 1 or
-                (len(type_modifiers) == 2 and
-                 type_modifiers[0].name == 'const'))
+            needs_name_removed = True
+            if len(type_modifiers) == 1:
+                needs_name_removed = False
+            else:
+                last = type_modifiers[-1].name
+                second_to_last = type_modifiers[-2].name
+                if (
+                    last == '>' or
+                    keywords.is_builtin_type(last) or
+                    second_to_last == '::' or
+                    keywords.is_builtin_type_modifiers(second_to_last)
+                ):
+                    needs_name_removed = False
 
             (name, type_name, templated_types, modifiers,
              _, __) = self.declaration_to_parts(type_modifiers,

--- a/cpp/keywords.py
+++ b/cpp/keywords.py
@@ -58,3 +58,10 @@ def is_builtin_type(token):
         # These only apply to methods, they can't be types by themselves.
         return False
     return token in TYPES or token in TYPE_MODIFIERS
+
+
+def is_builtin_type_modifiers(token):
+    if token in ('virtual', 'inline'):
+        # These only apply to methods, they can't be types by themselves.
+        return False
+    return token in TYPE_MODIFIERS

--- a/test_ast.py
+++ b/test_ast.py
@@ -516,7 +516,8 @@ class AstBuilderIntegrationTest(unittest.TestCase):
                          nodes[0])
 
     def test_function_one_argument_with_name(self):
-        for argument in ('Foo f', 'const Foo f', 'Foo& f', 'const Foo& f'):
+        for argument in ('Foo f', 'const Foo f', 'Foo& f', 'const Foo& f',
+                         'unsigned int f', 'ns::foo f', 'std::vector<int> f'):
             code = 'void fct(%s);' % argument
             nodes = list(MakeBuilder(code).generate())
             self.assertEqual(1, len(nodes))
@@ -524,7 +525,8 @@ class AstBuilderIntegrationTest(unittest.TestCase):
             self.assertEqual('f', nodes[0].parameters[0].name)
 
     def test_function_one_argument_with_no_name(self):
-        for argument in ('Foo', 'const Foo', 'Foo&', 'const Foo&'):
+        for argument in ('Foo', 'const Foo', 'Foo&', 'const Foo&',
+                         'unsigned int', 'ns::foo', 'std::vector<int>'):
             code = 'void fct(%s);' % argument
             nodes = list(MakeBuilder(code).generate())
             self.assertEqual(1, len(nodes))


### PR DESCRIPTION
These functions are now properly parsed:
void fct(unsigned int);
void fct(ns::foo);
void fct(std::vector<int>);
