### PR TITLE
Improve template parsing.

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -457,12 +457,15 @@ class TypeConverter(object):
                     elif tokens[new_end].name == '*':
                         pointer = True
                         new_end += 1
+                    elif tokens[new_end].name == '&':
+                        reference = True
+                        new_end += 1
                 add_type(self.to_type(new_tokens))
                 # If there is a comma after the template, we need to consume
                 # that here otherwise it becomes part of the name.
                 i = new_end
                 reference = pointer = array = False
-            elif token.name == ',':
+            elif token.name == ',' or token.name == '(':
                 add_type([])
                 reference = pointer = array = False
             elif token.name == '*':
@@ -471,7 +474,7 @@ class TypeConverter(object):
                 reference = True
             elif token.name == '[':
                 pointer = True
-            elif token.name == ']':
+            elif token.name == ']' or token.name == ')':
                 pass
             else:
                 name_tokens.append(token)

--- a/test/foo.h
+++ b/test/foo.h
@@ -285,3 +285,6 @@ class TypeBuilder : public Base<i<8>*, false> {};
 int* Foo::Get(){}
 int** Foo::Get(){}
 int*** Foo::Get(){}
+
+typedef boost::function<void(const boost::shared_array<uint8_t>&, uint32_t, bool)> ReadFinishedFunc;
+

--- a/test_ast.py
+++ b/test_ast.py
@@ -409,6 +409,55 @@ class TypeConverterToTypeTest(unittest.TestCase):
                  Type('Bling', templated_types=[Type('x')])]
         self.assertEqual(Type('Bar', templated_types=types), result[0])
 
+    def test_template_with_multiple_template_args_reference(self):
+        tokens = get_tokens('Foo<Bar<int>&, int>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('Bar', reference=True, templated_types=[Type('int')]),
+                 Type('int')]
+        self.assertEqual(Type('Foo', templated_types=types), result[0])
+
+    def test_template_with_multiple_template_args_pointer(self):
+        tokens = get_tokens('Foo<Bar<int>*, int>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('Bar', pointer=True, templated_types=[Type('int')]),
+                 Type('int')]
+        self.assertEqual(Type('Foo', templated_types=types), result[0])
+
+    def test_template_with_function_arg_zero_arg(self):
+        tokens = get_tokens('function<void ()>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('void')]
+        self.assertEqual(Type('function', templated_types=types), result[0])
+
+    def test_template_with_function_arg_one_arg(self):
+        tokens = get_tokens('function<void (int)>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('void'),
+                 Type('int')]
+        self.assertEqual(Type('function', templated_types=types), result[0])
+
+    def test_template_with_function_arg_two_args(self):
+        tokens = get_tokens('function<void (int, int)>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('void'),
+                 Type('int'),
+                 Type('int')]
+        self.assertEqual(Type('function', templated_types=types), result[0])
+
+    def test_template_with_function_arg_and_nested_template(self):
+        tokens = get_tokens('function<void(vector<int>&, int)>')
+        result = self.converter.to_type(list(tokens))
+        self.assertEqual(1, len(result))
+        types = [Type('void'),
+                 Type('vector', reference=True, templated_types=[Type('int')]),
+                 Type('int')]
+        self.assertEqual(Type('function', templated_types=types), result[0])
+
 
 class TypeConverterCreateReturnTypeTest(unittest.TestCase):
 


### PR DESCRIPTION
cppclean can now parse code like this:
typedef Foo<Bar<int>&, int> FooType;
typedef std::function<void ()> FuncType;

This fix #34.
