### PR TITLE
Issue 89: warning on using namespace in header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ htmlcov/
 *.egg*/
 .coverage
 .travis-solo/
+.project
+.pydevproject

--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -203,6 +203,14 @@ class WarningHunter(object):
 
         return included_files, forward_declarations
 
+    def _find_using_namespaces(self):
+        for node in self.ast_list:
+            if isinstance(node, ast.Using):
+                self._add_warning(
+                    "'using namespace ...' should not be used in a header file"
+                    ", ignoring rest of file",
+                    node)
+
     def _verify_include_files_used(self, file_uses, included_files):
         """Find all #include files that are unnecessary."""
         for include_file, use in file_uses.items():
@@ -433,8 +441,10 @@ class WarningHunter(object):
                 self._add_warning(msg, node)
 
     def _find_header_warnings(self):
-        included_files, forward_declarations = self._read_and_parse_includes()
-        self._find_unused_warnings(included_files, forward_declarations)
+        self._find_using_namespaces()
+        if(len(self.warnings) == 0):
+            included_files, forward_declarations = self._read_and_parse_includes()
+            self._find_unused_warnings(included_files, forward_declarations)
 
     def _find_public_function_warnings(self, node, name, primary_header,
                                        all_headers):

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -63,6 +63,7 @@ test/unused_static.cc:7: static data 'i'
 test/unused_static.cc:8: static data 'j'
 test/unused_static.cc:3: unused variable 'z'
 test/unused_static.cc:4: unused variable 'b'
+test/using.h:8: 'using namespace ...' should not be used in a header file, ignoring rest of file
 test/with_main.cc:2: 'include.h' already #included on line 1
 test/with_main.cc:3: 'include.h' already #included on line 1
 test/with_main.cc:9: 'Foo' forward declaration not expected in source file


### PR DESCRIPTION
Added a warning when 'using namespace' is used in a header file.
The rest of the file is ignored because the output could be incorrect.