### PR TITLE
check for empty namespace

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -644,7 +644,7 @@ class ASTBuilder(object):
                 self.namespaces.append(False)
                 continue
             if token.name == '}':
-                if self.namespaces.pop():
+                if self.namespaces and self.namespaces.pop():
                     self.namespace_stack.pop()
                 continue
 


### PR DESCRIPTION
Prior to this commit it was possible to pop from an empty list,
generating an IndexError