### PR TITLE
initialize name tokens

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -1428,6 +1428,7 @@ class ASTBuilder(object):
     def _get_class(self, class_type, templated_types):
         class_name = None
         class_token = self._get_next_token()
+        name_tokens = []
         if class_token.token_type != tokenize.NAME:
             assert_parse(class_token.token_type == tokenize.SYNTAX,
                          class_token)


### PR DESCRIPTION
Without the initialization it was possible to reference name_tokens
prior to it being defined later in the code:

    if not self._handling_typedef:
        name_tokens = [class_token] + name_tokens
        return self._get_method(name_tokens, 0, None, False)