### PR TITLE
handle std function

### DIFF
--- a/test.bash
+++ b/test.bash
@@ -13,7 +13,7 @@ rm -f '.tmp'
 $PYTHON ./cppclean \
     --include-path='test/external' \
     --exclude='ignore.cc' \
-    'test' | tr '\\' '/' > '.tmp' || true
+    'test' | tr '\\' '/' 2>&1 > '.tmp' || true
 diff --unified 'test/expected.txt' '.tmp'
 rm -f '.tmp'
 

--- a/test/std_function.h
+++ b/test/std_function.h
@@ -1,0 +1,5 @@
+template <class T>
+std::function<void(T)>
+foo() {
+    return T();
+}

--- a/test/std_function.h
+++ b/test/std_function.h
@@ -1,5 +1,5 @@
 template <class T>
 std::function<void(T)>
 foo() {
-    return T();
+    return [&](T a) {return a.method();};
 }


### PR DESCRIPTION
Prior to this pull request, the test case added with this pull request has a parsing error.

```
cppclean std_function.h
std_function.h: parsing error: (Token(u'>', 40, 41), [Token(u'std', 19, 22), Token(u'::', 22, 24), Token(u'function', 24, 32), Token(u'<', 32, 33)], [Token(u'T', 38, 39)])
```