### PR TITLE
Implement basic support for ctor initializer lists and exporting defines with values

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -97,10 +97,17 @@ class Define(Node):
         Node.__init__(self, start, end)
         self.name = name
         self.definition = definition
+        # TODO(christarazi):
+        # Defines aren't bound to namespaces, so this is just a stopgap
+        # solution.
+        self.namespace = []
 
     def __str__(self):
         value = '%s %s' % (self.name, self.definition)
         return self._string_helper(self.__class__.__name__, value)
+
+    def is_exportable(self):
+        return True
 
 
 class Include(Node):

--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -281,7 +281,10 @@ class Union(Class):
 class Function(_GenericDeclaration):
 
     def __init__(self, start, end, name, return_type, parameters,
-                 specializations, modifiers, templated_types, body, namespace):
+                 specializations, modifiers, templated_types, body, namespace,
+                 initializers=None):
+        if initializers is None:
+            initializers = {}
         _GenericDeclaration.__init__(self, start, end, name, namespace)
         converter = TypeConverter(namespace)
         self.return_type = converter.create_return_type(return_type)
@@ -290,6 +293,7 @@ class Function(_GenericDeclaration):
         self.modifiers = modifiers
         self.body = body
         self.templated_types = templated_types
+        self.initializers = initializers
 
     def is_declaration(self):
         return self.body is None
@@ -318,6 +322,14 @@ class Method(Function):
 
     def __init__(self, start, end, name, in_class, return_type, parameters,
                  specializations, modifiers, templated_types, body, namespace):
+        # TODO(christarazi):
+        # Add support for ctor initializers.
+        # For now, only inline defined ctors are supported because we would
+        # need to figure out how to keep state of which class is currently
+        # being processed in order to modify its body (var decls).
+        #
+        # Note: ctor initializers are inside Function because a inline defined
+        # class members are parsed as functions rather than methods.
         Function.__init__(self, start, end, name, return_type, parameters,
                           specializations, modifiers, templated_types,
                           body, namespace)
@@ -1072,13 +1084,18 @@ class ASTBuilder(object):
         assert_parse(token.token_type == tokenize.SYNTAX, token)
 
         # Handle ctor initializers.
+        # Supports C++11 method of direct initialization with braces.
+        initializers = {}
         if token.name == ':':
             while token.name != ';' and token.name != '{':
-                _, token = self.get_name()
-                if token.name == '(':
-                    list(self._get_matching_char('(', ')'))
-                elif token.name == '{':
-                    list(self._get_matching_char('{', '}'))
+                member, token = self.get_name()
+                member = member[0]
+                if token.name == '(' or token.name == '{':
+                    end = '}' if token.name == '{' else ')'
+                    initializers[member] = [x
+                            for x in list(self._get_matching_char(
+                                token.name, end))
+                            if x.name != ',' and x.name != end]
                 token = self._get_next_token()
 
         # Handle pointer to functions.
@@ -1145,7 +1162,8 @@ class ASTBuilder(object):
                           templated_types, body, self.namespace_stack)
         return Function(indices.start, indices.end, name.name, return_type,
                         parameters, specializations, modifiers,
-                        templated_types, body, self.namespace_stack)
+                        templated_types, body, self.namespace_stack,
+                        initializers)
 
     def _get_variable(self, tokens):
         name, type_name, templated_types, modifiers, default, _ = \
@@ -1532,6 +1550,27 @@ class ASTBuilder(object):
                              self.namespace_stack,
                              quiet=self.quiet)
             body = list(ast.generate())
+
+            ctor = None
+            for member in body:
+                if isinstance(member, Function) and member.name == class_name:
+                    ctor = member
+                    break
+
+            # Merge ctor initializers with class members.
+            if ctor:
+                initializers = body[body.index(ctor)].initializers
+                var_decls = [x for x in body
+                             if isinstance(x, VariableDeclaration)]
+                for var in var_decls:
+                    for key, val in initializers.items():
+                        # TODO: CT
+                        # In the future, support members that have ctors with
+                        # more than one parameter.
+                        if len(val) > 1:
+                            continue
+                        if len(val) == 1 and var.name == key.name:
+                            body[body.index(var)].initial_value = val[0].name
 
             if not self._handling_typedef:
                 token = self._get_next_token()

--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -249,8 +249,8 @@ class WarningHunter(object):
                 decl_uses[name] |= USES_REFERENCE
             except symbols.Error:
                 module = Module(name, None)
-                self.symbol_table.add_symbol(node.name, node.namespace, node,
-                                             module)
+                symbol_table.add_symbol(node.name, node.namespace, node,
+                                        module)
 
         def _do_lookup(name, namespace):
             try:

--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -289,7 +289,7 @@ class WarningHunter(object):
                     file_uses[name] |= USES_REFERENCE
 
         def _add_use(node, namespace, name=''):
-            if isinstance(node, str):
+            if isinstance(node, basestring):
                 name = node
             elif isinstance(node, list):
                 # name contains a list of tokens.

--- a/test.bash
+++ b/test.bash
@@ -8,6 +8,7 @@ do
 done
 
 $PYTHON ./cppclean test/c++11.h
+$PYTHON ./cppclean test/init_lists.h
 
 rm -f '.tmp'
 $PYTHON ./cppclean \

--- a/test/const_define.h
+++ b/test/const_define.h
@@ -1,0 +1,6 @@
+#ifndef CONST_DEFINE_H
+# define CONST_DEFINE_H
+
+# define CONST_DEFINE 1
+
+#endif //! CONST_DEFINE_H

--- a/test/init_lists.h
+++ b/test/init_lists.h
@@ -1,0 +1,22 @@
+#include "const_define.h"
+
+class A {
+  public:
+    A() :
+      abc(CONST_DEFINE),
+      efg(2),
+      hij(3)
+    {}
+  private:
+    int abc;
+    int efg;
+    int hij;
+};
+
+struct B {
+  int arg1;
+
+  B() :
+    arg1(CONST_DEFINE)
+  {}
+};

--- a/test_ast.py
+++ b/test_ast.py
@@ -1001,7 +1001,7 @@ class ASTBuilderIntegrationTest(unittest.TestCase):
         self.assertEqual(exp_ctor.return_type, ctor.return_type)
         self.assertEqual(exp_ctor, ctor)
         self.assertEqual(exp_var, [arg1, arg2, arg3])
-        self.assertEqual(Class('Foo', body=[exp_ctor, *exp_var]), nodes[0])
+        self.assertEqual(Class('Foo', body=[exp_ctor] + exp_var), nodes[0])
 
     def test_class_ctor_initializer_list_cpp11(self):
         code = """
@@ -1032,7 +1032,7 @@ class ASTBuilderIntegrationTest(unittest.TestCase):
         self.assertEqual(exp_ctor.return_type, ctor.return_type)
         self.assertEqual(exp_ctor, ctor)
         self.assertEqual(exp_var, [arg1, arg2, arg3])
-        self.assertEqual(Class('Foo', body=[exp_ctor, *exp_var]), nodes[0])
+        self.assertEqual(Class('Foo', body=[exp_ctor] + exp_var), nodes[0])
 
     def test_function_parses_operator_bracket(self):
         code = """

--- a/test_ast.py
+++ b/test_ast.py
@@ -972,6 +972,68 @@ class ASTBuilderIntegrationTest(unittest.TestCase):
                                templated_types=types1,),
                          nodes[0])
 
+    def test_class_ctor_initializer_list(self):
+        code = """
+        class Foo {
+          public:
+            Foo() :
+              arg1(1),
+              arg2(2),
+              arg3(3)
+            {}
+          private:
+            int arg1;
+            int arg2;
+            int arg3;
+        };
+        """
+        nodes = list(MakeBuilder(code).generate())
+        ctor = nodes[0].body[0]
+        arg1 = nodes[0].body[1]
+        arg2 = nodes[0].body[2]
+        arg3 = nodes[0].body[3]
+
+        exp_ctor = Function('Foo', [], [], modifiers=ast.FUNCTION_CTOR, body=[])
+        exp_var = [VariableDeclaration('arg1', Type('int'), initial_value='1'),
+                   VariableDeclaration('arg2', Type('int'), initial_value='2'),
+                   VariableDeclaration('arg3', Type('int'), initial_value='3')]
+
+        self.assertEqual(exp_ctor.return_type, ctor.return_type)
+        self.assertEqual(exp_ctor, ctor)
+        self.assertEqual(exp_var, [arg1, arg2, arg3])
+        self.assertEqual(Class('Foo', body=[exp_ctor, *exp_var]), nodes[0])
+
+    def test_class_ctor_initializer_list_cpp11(self):
+        code = """
+        class Foo {
+          public:
+            Foo() :
+              arg1{1},
+              arg2{2},
+              arg3{3}
+            {}
+          private:
+            int arg1;
+            int arg2;
+            int arg3;
+        };
+        """
+        nodes = list(MakeBuilder(code).generate())
+        ctor = nodes[0].body[0]
+        arg1 = nodes[0].body[1]
+        arg2 = nodes[0].body[2]
+        arg3 = nodes[0].body[3]
+
+        exp_ctor = Function('Foo', [], [], modifiers=ast.FUNCTION_CTOR, body=[])
+        exp_var = [VariableDeclaration('arg1', Type('int'), initial_value='1'),
+                   VariableDeclaration('arg2', Type('int'), initial_value='2'),
+                   VariableDeclaration('arg3', Type('int'), initial_value='3')]
+
+        self.assertEqual(exp_ctor.return_type, ctor.return_type)
+        self.assertEqual(exp_ctor, ctor)
+        self.assertEqual(exp_var, [arg1, arg2, arg3])
+        self.assertEqual(Class('Foo', body=[exp_ctor, *exp_var]), nodes[0])
+
     def test_function_parses_operator_bracket(self):
         code = """
         class A {


### PR DESCRIPTION
For now, the ctor initializer lists are only supported when they are defined inline. Please see the commit messages for more detail.

I have an idea on how to support them when defined outside the class, but it requires keeping state of which class has already been processed and if that ctor (method) belongs to that class. Not to mention the possibility of nested classes. Any help / guidance is greatly appreciated.

This fixes issue #56.