### PR TITLE
Add support for Qt smart pointers

### DIFF
--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -370,6 +370,9 @@ class WarningHunter(object):
                     # These are things like auto_ptr which do
                     # not require the class definition, only decl.
                     _add_reference(cls.name, namespace)
+                elif name.startswith('Q') and name.endswith("Pointer"):
+                    # Special case templated classes from the Qt framework.
+                    _add_reference(cls.name, namespace)
                 else:
                     _add_use(cls.name, namespace)
                 _add_template_use(cls.name, cls.templated_types,

--- a/test/qt.h
+++ b/test/qt.h
@@ -1,0 +1,10 @@
+class QSomeClass;
+
+class QSomeOtherClass {
+    QPointer<QSomeClass> ptr1;
+    QSharedDataPointer<QSomeClass> ptr2;
+    QSharedPointer<QSomeClass> ptr3;
+    QWeakPointer<QSomeClass> ptr4;
+    QScopedPointer<QSomeClass> ptr5;
+    QScopedArrayPointer<QSomeClass> ptr6;
+};


### PR DESCRIPTION
This should get rid of the warnings for a forward declaration that must be included when using [Qt smart pointers](https://wiki.qt.io/Smart_Pointers). Mentioned in issue #60.