### PR TITLE
Prevent from crash when macros are present in ctor initializer list

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -1090,6 +1090,10 @@ class ASTBuilder(object):
         initializers = {}
         if token.name == ':':
             while token.name != ';' and token.name != '{':
+                # skip preprocesors macros
+                if token.name.startswith(('#if', '#elif',  '#else', '#endif')):
+                    token = self._get_next_token()
+                    continue
                 member, token = self.get_name()
                 member = member[0]
                 if token.name == '(' or token.name == '{':

--- a/test/ctor_init_list.h
+++ b/test/ctor_init_list.h
@@ -1,0 +1,14 @@
+class Foo {
+public:
+    int first,
+#if defined(TEST)
+    int second;
+#endif
+};
+
+Foo::Foo():
+    first(1)
+    #if defined(TEST)   // this 3 lines
+    ,second(2)          // generated
+    #endif              // IndexError: list index out of range
+{}


### PR DESCRIPTION
Fix for #132.
Different approach than #134, with working tests :)

----------
This only skips tokens if find macro, to prevent from crash.
Smarted solution is needed? 