### PR TITLE
Fix for include .hxx file #155

### DIFF
--- a/cpp/find_warnings.py
+++ b/cpp/find_warnings.py
@@ -182,8 +182,7 @@ class WarningHunter(object):
                     module = self._get_module(node)
                     filename = module.filename
                     _, ext = os.path.splitext(filename)
-                    if ext.lower() != '.hxx':
-                        included_files[filename] = node, module
+                    included_files[filename] = node, module
                 if is_cpp_file(filename):
                     self._add_warning(
                         "should not #include C++ source file '{}'".format(

--- a/test/a.hxx
+++ b/test/a.hxx
@@ -1,0 +1,8 @@
+#ifndef _A_H_
+#define _A_H_
+
+#include "b.hxx"
+
+void myFunc(int a);
+
+#endif

--- a/test/b.hxx
+++ b/test/b.hxx
@@ -1,0 +1,14 @@
+#ifndef _B_H_
+#define _B_H_
+
+namespace Name1 {
+class ABC {
+public:
+  ABC(): int1(0) {}
+  int getInt() { return int1; }
+private:
+  int int1;
+};
+}
+
+#endif

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -1,3 +1,4 @@
+test/a.hxx:4: 'b.hxx' does not need to be #included
 test/baz.h:1: 'bar.h' does not need to be #included; use a forward declaration instead
 test/baz.h:2: 'bar_bis.h' does not need to be #included; use a forward declaration instead
 test/cxx.cxx:1: 'cxx' not found in any directly #included header
@@ -18,6 +19,7 @@ test/foo.h:87: 'string' already #included on line 3
 test/foo.h:113: 'not-used.h' does not need to be #included
 test/foo.h:150: 'AR' not used
 test/foo.h:221: unable to find 'dir//bar.h'
+test/foo.h:307: 'foo.hxx' does not need to be #included; use a forward declaration instead
 test/foo.h:234 'Colon' has virtual methods without a virtual dtor
 test/foo.h:20: static data 'd'
 test/foo.h:101: static data 'ptof'


### PR DESCRIPTION
This change is for fixing issue #155 reported by me. Please pull and merge this.

Note: Our project use extension .hxx for c++ header files and .h for c header files. 
cppclean should not differentiate between .h and .hxx files.